### PR TITLE
Get rid of errors when observers will remove

### DIFF
--- a/addon/components/scroll-container.js
+++ b/addon/components/scroll-container.js
@@ -18,13 +18,13 @@ export default Component.extend({
     //Check if in viewport then set
     this.set('active', this.viewportHandler.current === linkId);
 
-    this.addObserver(`viewportHandler.current`, this, this.setViewportHandler);
+    this.addObserver('viewportHandler.current', this, this.setViewportHandler);
   },
 
   willDestroy() {
     this._super();
     this.removeObserver(
-      `viewportHandler.${this.linkId}`,
+      'viewportHandler.current',
       this,
       this.setViewportHandler
     );

--- a/addon/components/scroll-container.js
+++ b/addon/components/scroll-container.js
@@ -1,29 +1,36 @@
 import Component from '@ember/component';
-import { inject as service } from "@ember/service";
+import { inject as service } from '@ember/service';
 import layout from '../templates/components/scroll-container';
 
 export default Component.extend({
-    viewportHandler: service('viewport-handler'),
-    tagName: 'span',
+  viewportHandler: service('viewport-handler'),
+  tagName: 'span',
 
-    classNameBindings: ['active'],
-    layout,
-    
-    init(){
-        this._super(...arguments);
-        const linkId = this.linkId;
-        this.set(`viewportHandler.${linkId}`, false);
-        this.set('viewportHandler.current', null);
+  classNameBindings: ['active'],
+  layout,
 
-        //Check if in viewport then set 
-        this.set('active', this.viewportHandler.current === linkId);
+  init() {
+    this._super(...arguments);
+    const linkId = this.linkId;
+    this.set(`viewportHandler.${linkId}`, false);
+    this.set('viewportHandler.current', null);
 
-        this.addObserver(`viewportHandler.current`,function() {
-            this.set('active', this.viewportHandler.current === linkId);
-        });
-      },
-      willDestroy() {
-        this._super();
-        this.removeObserver(`viewportHandler.${this.linkId}`);
-      }
+    //Check if in viewport then set
+    this.set('active', this.viewportHandler.current === linkId);
+
+    this.addObserver(`viewportHandler.current`, this, this.setViewportHandler);
+  },
+
+  willDestroy() {
+    this._super();
+    this.removeObserver(
+      `viewportHandler.${this.linkId}`,
+      this,
+      this.setViewportHandler
+    );
+  },
+
+  setViewportHandler() {
+    this.set('active', this.viewportHandler.current === this.linkId);
+  },
 });


### PR DESCRIPTION
# Reason:
In Ember 3.24 occurs errors when try remove observers, fixed by https://deprecations.emberjs.com/v3.x/#toc_events-remove-all-listeners